### PR TITLE
Resolves #5: Create basic Profile component

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,6 +12,7 @@ import EditProfile from "./components/profile-forms/EditProfile";
 import AddExperience from "./components/profile-forms/AddExperience";
 import AddEducation from "./components/profile-forms/AddEducation";
 import Profiles from "./components/profiles/Profiles";
+import Profile from "./components/profile/Profile";
 import PrivateRoute from "./components/routing/PrivateRoute";
 // Redux
 import { Provider } from "react-redux";
@@ -40,6 +41,7 @@ const App = () => {
               <Route exact path="/register" component={Register} />
               <Route exact path="/login" component={Login} />
               <Route exact path="/profiles" component={Profiles} />
+              <Route exact path="/profile/:id" component={Profile} />
               <PrivateRoute exact path="/dashboard" component={Dashboard} />
               <PrivateRoute
                 exact

--- a/client/src/components/dashboard/Dashboard.js
+++ b/client/src/components/dashboard/Dashboard.js
@@ -16,7 +16,7 @@ const Dashboard = ({
 }) => {
   useEffect(() => {
     getCurrentProfile();
-  }, []);
+  }, [getCurrentProfile]);
 
   return loading && profile === null ? (
     <Spinner />

--- a/client/src/components/profile-forms/AddEducation.js
+++ b/client/src/components/profile-forms/AddEducation.js
@@ -1,5 +1,5 @@
 import React, { Fragment, useState } from 'react'
-import { Link, withRouter } from "react-router-dom";
+import { withRouter } from "react-router-dom";
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux';
 import { addEducation } from "../../actions/profile";
@@ -79,4 +79,7 @@ AddEducation.propTypes = {
     addEducation: PropTypes.func.isRequired,
 }
 
-export default connect(null, { addEducation })(AddEducation);
+export default connect(
+    null, 
+    { addEducation }
+)(withRouter(AddEducation));

--- a/client/src/components/profile-forms/AddExperience.js
+++ b/client/src/components/profile-forms/AddExperience.js
@@ -1,5 +1,5 @@
 import React, { Fragment, useState } from 'react'
-import { Link, withRouter } from "react-router-dom";
+import { withRouter } from "react-router-dom";
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux';
 import { addExperience } from "../../actions/profile";
@@ -53,7 +53,7 @@ const AddExperience = ({ addExperience, history }) => {
                     <p><input type="checkbox" name="current" checked={current} value={current} onChange={e => { 
                         setFormData({ ...formData, current: !current }); 
                         toggleDisabled(!toDateDisabled)
-                        }} value="" /> Current Job</p>
+                        }} /> Current Job</p>
                 </div>
                 <div className="form-group">
                     <h4>To Date</h4>
@@ -80,4 +80,7 @@ AddExperience.propTypes = {
     addExperience: PropTypes.func.isRequired,
 }
 
-export default connect(null, { addExperience })(AddExperience);
+export default connect(
+    null, 
+    { addExperience }
+)(withRouter(AddExperience));

--- a/client/src/components/profile-forms/EditProfile.js
+++ b/client/src/components/profile-forms/EditProfile.js
@@ -60,7 +60,7 @@ const EditProfile = ({
       youtube: loading || !profile.social ? "" : profile.social.youtube,
       instagram: loading || !profile.social ? "" : profile.social.instagram,
     });
-  }, [loading]);
+  }, [loading, getCurrentProfile]);
 
   const onChange = (e) =>
     setFormData({ ...formData, [e.target.name]: e.target.value });

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -1,0 +1,51 @@
+import React, { Fragment, useEffect } from "react";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import Spinner from "../layout/Spinner";
+import { getProfileById } from "../../actions/profile";
+
+const Profile = ({ 
+    getProfileById, 
+    profile: { profile, loading },
+    auth,
+    match
+ }) => {
+    useEffect(() => {
+        getProfileById(match.params.id);
+    }, [getProfileById]);
+
+    return (
+        <Fragment>
+           { profile === null || loading ? <Spinner/> : 
+            <Fragment>
+                <Link to="/profiles" className="btn btn-light">
+                    Back to Profiles
+                </Link>
+                { auth.isAuthenticated && 
+                    auth.loading === false && 
+                    auth.user._id === profile.user._id &&
+                    <Link to="/edit-profile" className="btn btn-dark">
+                        Edit Profile
+                    </Link>
+                }
+            </Fragment>
+           }
+        </Fragment>
+    )
+}
+
+Profile.propTypes = {
+    getProfileById: PropTypes.func.isRequired,
+    profile: PropTypes.object.isRequired,
+    auth: PropTypes.object.isRequired,
+}
+
+const mapStateToProps = state => ({
+    profile: state.profile,
+    auth: state.auth
+});
+
+export default connect(mapStateToProps, 
+    { getProfileById }
+)(Profile)

--- a/client/src/components/profiles/Profiles.js
+++ b/client/src/components/profiles/Profiles.js
@@ -9,7 +9,7 @@ const Profiles = ({ getProfiles, profile: { profiles, loading }}) => {
 
     useEffect(() => {
         getProfiles();
-    }, []);
+    }, [getProfiles]);
 
     return (
         <Fragment>


### PR DESCRIPTION
### Changes
* `View Profile` button with individual user profile route now links to `Profile` component.
* `Back to Profiles` button redirects the user back to the Developers page.
* If the user is logged in and `user._id` matches `profile.user._id`, display an `Edit Profile` button.

### Screenshot
![image](https://user-images.githubusercontent.com/59207653/85040398-c2b27300-b156-11ea-897a-a9a217d8ee36.png)


![image](https://user-images.githubusercontent.com/59207653/85040354-b4fced80-b156-11ea-857c-74b61c854523.png)


Signed-off-by: Alif Munim <alif.munim@ryerson.ca>