### PR TITLE
Resolves #7: Add ProfileTop and ProfileAbout Components

### DIFF
--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import Spinner from "../layout/Spinner";
+import ProfileTop from "./ProfileTop";
+import ProfileAbout from "./ProfileAbout";
 import { getProfileById } from "../../actions/profile";
 
 const Profile = ({ 
@@ -13,7 +15,7 @@ const Profile = ({
  }) => {
     useEffect(() => {
         getProfileById(match.params.id);
-    }, [getProfileById]);
+    }, [getProfileById, match.params.id]);
 
     return (
         <Fragment>
@@ -29,6 +31,10 @@ const Profile = ({
                         Edit Profile
                     </Link>
                 }
+                <div class="profile-grid my-1">
+                    <ProfileTop profile={profile} />
+                    <ProfileAbout profile={profile} />
+                </div>
             </Fragment>
            }
         </Fragment>

--- a/client/src/components/profile/ProfileAbout.js
+++ b/client/src/components/profile/ProfileAbout.js
@@ -1,0 +1,45 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+
+const ProfileAbout = ({ profile: {
+    bio,
+    skills,
+    user: { name }
+}}) => {
+    
+    return (
+        <div class="profile-about bg-light p-2">
+
+            { bio && (
+                <Fragment>
+                    <h2 class="text-primary">{name.trim().split(" ")[0]}'s Bio</h2>
+                    <p>{bio}</p>
+                    <div class="line"></div>
+                </Fragment>
+            )}
+
+            
+            
+            <h2 class="text-primary">Skill Set</h2>
+            <div class="skills">
+
+                {
+                    skills.map((skill, index) => (
+                        <div key={index} className="p-1">
+                            <i className="fas fa-check"></i> {skill}
+                        </div>
+                    ))
+                }
+                
+                
+            </div>
+        </div>
+    )
+    
+}
+
+ProfileAbout.propTypes = {
+    profile: PropTypes.object.isRequired,
+}
+
+export default ProfileAbout

--- a/client/src/components/profile/ProfileTop.js
+++ b/client/src/components/profile/ProfileTop.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const ProfileTop = ({ profile: {
+    status,
+    company,
+    location,
+    website,
+    social,
+    user: { name, avatar }
+}}) => {
+    return (
+        <div className="profile-top bg-primary p-2">
+            <img
+                className="round-img my-1"
+                src={avatar}
+                alt=""
+            />
+            <h1 className="large">{name}</h1>
+            <p className="lead">{status} {company && <span>at {company}</span>}</p>
+            <p>{location && <span>{location}</span>}</p>
+            <div className="icons my-1">
+                {
+                    website && (
+                        <a href={website} target="_blank" rel="noopener noreferrer">
+                            <i className="fas fa-globe fa-2x"></i>
+                        </a>
+                    )
+                }
+
+                {
+                    social && social.twitter && (
+                        <a href={social.twitter} target="_blank" rel="noopener noreferrer">
+                            <i className="fab fa-twitter fa-2x"></i>
+                        </a>
+                    )
+                }
+                
+                {
+                    social && social.facebook && (
+                        <a href={social.facebook} target="_blank" rel="noopener noreferrer">
+                            <i className="fab fa-facebook fa-2x"></i>
+                        </a>
+                    )
+                }
+                
+                {
+                    social && social.linkedin && (
+                        <a href={social.linkedin} target="_blank" rel="noopener noreferrer">
+                            <i className="fab fa-linkedin fa-2x"></i>
+                        </a>
+                    )
+                }
+
+                {
+                    social && social.youtube && (
+                        <a href={social.youtube} target="_blank" rel="noopener noreferrer">
+                            <i className="fab fa-youtube fa-2x"></i>
+                        </a>
+                    )
+                }
+                
+                {
+                    social && social.instagram && (
+                        <a href={social.instagram} target="_blank" rel="noopener noreferrer">
+                            <i className="fab fa-instagram fa-2x"></i>
+                        </a>
+                    )
+                }
+                
+                
+                
+            </div>
+        </div>
+    );
+}
+
+ProfileTop.propTypes = {
+    profile: PropTypes.object.isRequired
+};
+
+export default ProfileTop;


### PR DESCRIPTION
### Changes
* Create `ProfileTop` component to display the user's avatar, status, company, and social links if applicable
* Create `ProfileAbout` component to display the user's bio and map each skill next to an icon in small text form

### Screenshot
![image](https://user-images.githubusercontent.com/59207653/85060884-f354d580-b173-11ea-8a75-65193069e605.png)


Signed-off-by: Alif Munim <alif.munim@ryerson.ca>