### PR TITLE
Resolves #8: Add ProfileEducation and ProfileExperience Components

### DIFF
--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -5,6 +5,8 @@ import { connect } from "react-redux";
 import Spinner from "../layout/Spinner";
 import ProfileTop from "./ProfileTop";
 import ProfileAbout from "./ProfileAbout";
+import ProfileExperience from "./ProfileExperience";
+import ProfileEducation from "./ProfileEducation";
 import { getProfileById } from "../../actions/profile";
 
 const Profile = ({ 
@@ -34,6 +36,33 @@ const Profile = ({
                 <div class="profile-grid my-1">
                     <ProfileTop profile={profile} />
                     <ProfileAbout profile={profile} />
+                    <div className="profile-exp bg-white p-2">
+                        <h2 className="text-primary">Experience</h2>
+                        { profile.experience.length > 0 ? (
+                                <Fragment>
+                                    {
+                                        profile.experience.map((experience) => (
+                                            <ProfileExperience key={experience._id} experience={experience} />
+                                        ))
+                                    }
+                                </Fragment>
+                            ) : (<h4>No experience credientials</h4>)
+                        }
+                    </div>
+                    <div className="profile-edu bg-white p-2">
+                        <h2 className="text-primary">Education</h2>
+                        { profile.education.length > 0 ? (
+                                <Fragment>
+                                    {
+                                        profile.education.map((education) => (
+                                            <ProfileEducation key={education._id} education={education} />
+                                        ))
+                                    }
+                                </Fragment>
+                            ) : (<h4>No education credientials</h4>)
+                        }
+                    </div>
+        
                 </div>
             </Fragment>
            }

--- a/client/src/components/profile/ProfileEducation.js
+++ b/client/src/components/profile/ProfileEducation.js
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Moment from "react-moment";
+
+const ProfileEducation = ({ education: {
+    school,
+    degree,
+    fieldofstudy,
+    current,
+    to, 
+    from,
+    description
+}}) => {
+    return (
+        <div>
+            <h3 className="text-dark">{school}</h3>
+            <p>
+                <Moment format="YYYY/MM/DD">{from}</Moment> - {!to ? " Now" : 
+                <Moment format="YYYY/MM/DD">{to}</Moment>}
+            </p>
+            <p>
+                <strong>Degree:</strong> {degree}
+            </p>
+            <p>
+                <strong>Field of Study:</strong> {fieldofstudy}
+            </p>
+            <p>
+                <strong>Description:</strong> {description}
+            </p>
+        </div>
+    )
+}
+
+ProfileEducation.propTypes = {
+    education: PropTypes.array.isRequired,
+}
+
+export default ProfileEducation

--- a/client/src/components/profile/ProfileExperience.js
+++ b/client/src/components/profile/ProfileExperience.js
@@ -1,0 +1,35 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Moment from "react-moment";
+
+const ProfileExperience = ({ experience: {
+    company,
+    title,
+    location,
+    current,
+    to, 
+    from,
+    description
+}}) => {
+    return (
+        <div>
+            <h3 className="text-dark">{company}</h3>
+            <p>
+                <Moment format="YYYY/MM/DD">{from}</Moment> - {!to ? " Now" : 
+                <Moment format="YYYY/MM/DD">{to}</Moment>}
+            </p>
+            <p>
+                <strong>Position:</strong> {title}
+            </p>
+            <p>
+                <strong>Description:</strong> {description}
+            </p>
+        </div>
+    )
+}
+
+ProfileExperience.propTypes = {
+    experience: PropTypes.array.isRequired,
+}
+
+export default ProfileExperience


### PR DESCRIPTION
### Changes
* Add `ProfileEducation` component which displays previous schools along with degree, field of study, timeframe, and description.
* Add `ProfileExperience` component which displays previous companies along with position, timeframe, and description.

### Screenshot
![image](https://user-images.githubusercontent.com/59207653/85063642-70824980-b178-11ea-9af8-bb4c07fd162f.png)


Signed-off-by: Alif Munim <alif.munim@ryerson.ca>