### PR TITLE
Resolves #9: Add ProfileGithub Component

### DIFF
--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -7,6 +7,7 @@ import ProfileTop from "./ProfileTop";
 import ProfileAbout from "./ProfileAbout";
 import ProfileExperience from "./ProfileExperience";
 import ProfileEducation from "./ProfileEducation";
+import ProfileGithub from "./ProfileGithub";
 import { getProfileById } from "../../actions/profile";
 
 const Profile = ({ 
@@ -62,6 +63,10 @@ const Profile = ({
                             ) : (<h4>No education credientials</h4>)
                         }
                     </div>
+
+                    { profile.githubusername && (
+                        <ProfileGithub username={profile.githubusername}/>
+                    )}
         
                 </div>
             </Fragment>

--- a/client/src/components/profile/ProfileAbout.js
+++ b/client/src/components/profile/ProfileAbout.js
@@ -8,20 +8,20 @@ const ProfileAbout = ({ profile: {
 }}) => {
     
     return (
-        <div class="profile-about bg-light p-2">
+        <div className="profile-about bg-light p-2">
 
             { bio && (
                 <Fragment>
-                    <h2 class="text-primary">{name.trim().split(" ")[0]}'s Bio</h2>
+                    <h2 className="text-primary">{name.trim().split(" ")[0]}'s Bio</h2>
                     <p>{bio}</p>
-                    <div class="line"></div>
+                    <div className="line"></div>
                 </Fragment>
             )}
 
             
             
-            <h2 class="text-primary">Skill Set</h2>
-            <div class="skills">
+            <h2 className="text-primary">Skill Set</h2>
+            <div className="skills">
 
                 {
                     skills.map((skill, index) => (

--- a/client/src/components/profile/ProfileGithub.js
+++ b/client/src/components/profile/ProfileGithub.js
@@ -1,0 +1,57 @@
+import React, { useEffect } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { getGithubRepos } from "../../actions/profile";
+import Spinner from "../layout/Spinner";
+
+const ProfileGithub = ({ username, getGithubRepos, repos }) => {
+
+    useEffect(() => {
+        getGithubRepos(username);
+    }, [getGithubRepos]);
+
+    return (
+        <div className="profile-github">
+            <h2 className="text-primary my-1">Github Repos</h2>
+            {repos === null ? <Spinner /> : (
+                repos.map((repo) => (
+                    <div key={repo._id} className="repo bg-white p-1 my-1">
+                        <div>
+                            <h4>
+                                <a href={repo.html_url} target="_blank" rel="noopener noreferrer">
+                                    {repo.name}
+                                </a>
+                            </h4>
+                            <p>{repo.description}</p>
+                        </div>
+                        <div>
+                            <ul>
+                                <li className="badge badge-primary">
+                                    Stars: {repo.stargazers_count}
+                                </li>
+                                <li className="badge badge-dark">
+                                    Watchers: {repo.watchers_count}
+                                </li>
+                                <li className="badge badge-light">
+                                    Forks: {repo.forks_count}
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                ))
+            )}
+        </div>
+    )
+}
+
+ProfileGithub.propTypes = {
+    getGithubRepos: PropTypes.func.isRequired,
+    repos: PropTypes.array.isRequired,
+    username: PropTypes.string.isRequired,
+}
+
+const mapStateToProps = state => ({
+    repos: state.profile.repos
+})
+
+export default connect(mapStateToProps, { getGithubRepos })(ProfileGithub);

--- a/client/src/reducers/profile.js
+++ b/client/src/reducers/profile.js
@@ -37,6 +37,7 @@ export default function (state = initialState, action) {
         ...state,
         error: payload,
         loading: false,
+        profile: null
       };
     case CLEAR_PROFILE:
       return {


### PR DESCRIPTION
### Changes
* Create `ProfileGithub` component which uses the `getGithubRepos` action to retrieve a list of the user's GitHub repos, if applicable.
* Map through the retrieved repos and create informational cards for each.

### Screenshot
![image](https://user-images.githubusercontent.com/59207653/85068553-9f042280-b180-11ea-84e3-d7a9fd1f8ff4.png)


Signed-off-by: Alif Munim <alif.munim@ryerson.ca>