### PR TITLE
Resolves #13: Create initial types, actions & reducers for posts

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,6 +13,7 @@ import AddExperience from "./components/profile-forms/AddExperience";
 import AddEducation from "./components/profile-forms/AddEducation";
 import Profiles from "./components/profiles/Profiles";
 import Profile from "./components/profile/Profile";
+import Posts from "./components/posts/Posts";
 import PrivateRoute from "./components/routing/PrivateRoute";
 // Redux
 import { Provider } from "react-redux";
@@ -63,6 +64,7 @@ const App = () => {
                 path="/add-education"
                 component={AddEducation}
               />
+              <PrivateRoute exact path="/posts" component={Posts} />
             </Switch>
           </section>
         </Fragment>

--- a/client/src/actions/post.js
+++ b/client/src/actions/post.js
@@ -1,0 +1,23 @@
+import axios from "axios";
+import { setAlert } from "./alert";
+import {
+    GET_POSTS,
+    POST_ERROR
+} from "./types";
+
+// Get posts
+export const getPosts = () => async dispatch => {
+    try {
+        const res = await axios.get("api/posts");
+        dispatch({
+            type: GET_POSTS,
+            payload: res.data
+        });
+    } catch (err) {
+        dispatch({
+            type: POST_ERROR,
+            payload: { msg: err.response.statusText, status: err.respons.status }
+        });
+    }
+}
+

--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -14,4 +14,6 @@ export const UPDATE_PROFILE = "UPDATE_PROFILE";
 export const CLEAR_PROFILE = "CLEAR_PROFILE";
 export const PROFILE_ERROR = "PROFILE_ERROR";
 export const ACCOUNT_DELETED = "ACCOUNT_DELETED";
+export const GET_POSTS = "GET_POSTS";
+export const POST_ERROR = "POST_ERROR";
 

--- a/client/src/components/layout/Navbar.js
+++ b/client/src/components/layout/Navbar.js
@@ -11,6 +11,9 @@ const Navbar = ({ auth: { isAuthenticated, loading }, logout }) => {
         <Link to="/profiles">Developers</Link>
       </li>
       <li>
+        <Link to="/posts">Posts</Link>
+      </li>
+      <li>
         <Link to="/dashboard">
           <i className="fas fa-user"></i>{" "}
           <span className="hide-sm">Dashboard</span>

--- a/client/src/components/posts/Posts.js
+++ b/client/src/components/posts/Posts.js
@@ -1,0 +1,29 @@
+import React, { Fragment, useEffect } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { getPosts } from "../../actions/post";
+import Spinner from "../layout/Spinner";
+
+const Posts = ({ getPosts, post: { posts, loading } }) => {
+
+    useEffect(() => {
+        getPosts();
+    }, [getPosts]);
+
+    return (
+        <div>
+            
+        </div>
+    )
+}
+
+Posts.propTypes = {
+    getPosts: PropTypes.func.isRequired,
+    post: PropTypes.object.isRequired,
+}
+
+const mapStateToProps = state => ({
+    post: state.post
+});
+
+export default connect(mapStateToProps, { getPosts })(Posts);

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -2,9 +2,11 @@ import { combineReducers } from "redux";
 import alert from "./alert";
 import auth from "./auth";
 import profile from "./profile";
+import post from "./post";
 
 export default combineReducers({
   alert,
   auth,
   profile,
+  post
 });

--- a/client/src/reducers/post.js
+++ b/client/src/reducers/post.js
@@ -1,0 +1,33 @@
+import {
+    GET_POSTS,
+    POST_ERROR
+} from "../actions/types";
+
+const initialState = {
+    posts: [],
+    post: null,
+    loading: true,
+    error: {}
+}
+
+export default function(state=initialState, action) {
+    const { type, payload } = action;
+
+    switch(type) {
+        case GET_POSTS:
+            return {
+                ...state,
+                posts: payload,
+                loading: false
+            }
+        case GET_POSTS:
+            return {
+                ...state,
+                error: payload,
+                loading: false
+            }
+        default:
+            return state;
+        
+    }
+}


### PR DESCRIPTION
### Changes
* Create `GET_POSTS` type as well as a corresponding **reducer** and **action**.
  * Make a request to `api/posts` using **axios** and dispatch the resulting type and payload.
  * Handle the action using switch cases in the `posts.js` reducer.
* Add `Posts` as a private route in **App.js**.
* Add `Posts` link to navigation.

### Screenshot
![image](https://user-images.githubusercontent.com/59207653/85215856-3a95be80-b34c-11ea-91a8-8c82d0ecf112.png)


Signed-off-by: Alif Munim <alif.munim@ryerson.ca>